### PR TITLE
Add posts API with pagination, custom error handling, and Swagger docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,18 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                  <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-test</artifactId>
+                          <scope>test</scope>
+                  </dependency>
+
+                  <dependency>
+                          <groupId>org.springdoc</groupId>
+                          <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                          <version>2.3.0</version>
+                  </dependency>
+          </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/demo/client/PostClient.java
+++ b/src/main/java/com/example/demo/client/PostClient.java
@@ -1,0 +1,8 @@
+package com.example.demo.client;
+
+import com.example.demo.domain.Post;
+import java.util.List;
+
+public interface PostClient {
+    List<Post> fetchPosts();
+}

--- a/src/main/java/com/example/demo/client/PostClientImpl.java
+++ b/src/main/java/com/example/demo/client/PostClientImpl.java
@@ -1,0 +1,28 @@
+package com.example.demo.client;
+
+import com.example.demo.domain.Post;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class PostClientImpl implements PostClient {
+
+    private final RestTemplate restTemplate;
+    private final String postsApi;
+
+    public PostClientImpl(RestTemplateBuilder builder,
+                          @Value("${external.posts.api:https://jsonplaceholder.typicode.com/posts}") String postsApi) {
+        this.restTemplate = builder.build();
+        this.postsApi = postsApi;
+    }
+
+    @Override
+    public List<Post> fetchPosts() {
+        Post[] response = restTemplate.getForObject(postsApi, Post[].class);
+        return Arrays.asList(response);
+    }
+}

--- a/src/main/java/com/example/demo/config/OpenApiConfig.java
+++ b/src/main/java/com/example/demo/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.demo.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI demoOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Demo API")
+                        .description("Demo application with posts API")
+                        .version("v1"));
+    }
+}

--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -1,0 +1,30 @@
+package com.example.demo.controller;
+
+import com.example.demo.domain.Post;
+import com.example.demo.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/posts")
+@Tag(name = "Posts")
+public class PostController {
+
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @GetMapping
+    @Operation(summary = "Get posts", description = "Returns paginated posts")
+    public List<Post> getPosts(@RequestParam(defaultValue = "1") int page,
+                               @RequestParam(defaultValue = "10") int size) {
+        return postService.getPosts(page, size);
+    }
+}

--- a/src/main/java/com/example/demo/domain/Post.java
+++ b/src/main/java/com/example/demo/domain/Post.java
@@ -1,0 +1,3 @@
+package com.example.demo.domain;
+
+public record Post(long userId, long id, String title, String body) {}

--- a/src/main/java/com/example/demo/exception/ApiError.java
+++ b/src/main/java/com/example/demo/exception/ApiError.java
@@ -1,0 +1,5 @@
+package com.example.demo.exception;
+
+import java.time.LocalDateTime;
+
+public record ApiError(int status, String message, LocalDateTime timestamp) {}

--- a/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.example.demo.exception;
+
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex) {
+        ApiError error = new ApiError(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler(RestClientException.class)
+    public ResponseEntity<ApiError> handleRestClient(RestClientException ex) {
+        ApiError error = new ApiError(HttpStatus.BAD_GATEWAY.value(), ex.getMessage(), LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleGeneric(Exception ex) {
+        ApiError error = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(), LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+}

--- a/src/main/java/com/example/demo/service/PostService.java
+++ b/src/main/java/com/example/demo/service/PostService.java
@@ -1,0 +1,8 @@
+package com.example.demo.service;
+
+import com.example.demo.domain.Post;
+import java.util.List;
+
+public interface PostService {
+    List<Post> getPosts(int page, int size);
+}

--- a/src/main/java/com/example/demo/service/PostServiceImpl.java
+++ b/src/main/java/com/example/demo/service/PostServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.demo.service;
+
+import com.example.demo.client.PostClient;
+import com.example.demo.domain.Post;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostServiceImpl implements PostService {
+
+    private final PostClient postClient;
+
+    public PostServiceImpl(PostClient postClient) {
+        this.postClient = postClient;
+    }
+
+    @Override
+    public List<Post> getPosts(int page, int size) {
+        if (page < 1 || size < 1) {
+            throw new IllegalArgumentException("Page and size must be positive");
+        }
+        List<Post> allPosts = postClient.fetchPosts();
+        int fromIndex = Math.min((page - 1) * size, allPosts.size());
+        if (fromIndex >= allPosts.size()) {
+            return Collections.emptyList();
+        }
+        int toIndex = Math.min(fromIndex + size, allPosts.size());
+        return allPosts.subList(fromIndex, toIndex);
+    }
+}


### PR DESCRIPTION
## Summary
- add Post domain and client to fetch data from external JSONPlaceholder API
- implement service and controller to provide paginated `/posts` endpoint with Swagger documentation
- introduce global exception handler returning custom error responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; repository unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e92a3dc90833299ed0b26d0703747